### PR TITLE
build/rules.mk: Fix the `all` target running twice

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -9,6 +9,7 @@ PLUGIN_TEST_BIN_DIR ?= $(PLUGIN_TEST_SUPPORT_DIR)/$(shell arch)/bin
 .PHONY: travis-install-arduino astyle travis-test travis-check-astyle travis-smoke-examples test
 
 all: build-all
+	@: ## Do not remove this line, otherwise `make all` will trigger the `%` rule too.
 
 astyle:	
 	$(PLUGIN_TEST_SUPPORT_DIR)/run-astyle


### PR DESCRIPTION
If a rule has no body, make considers it a dependency-only rule, and will run any other rules that match our target, after running the dependency. In practice, this meant that `make all` - which appears to be the default - ran both `kaleidoscope-builder build-all`, and `kaleidoscope-builder all` (due to the catch-all `%` rule at the end). The latter is an error.

This little change adds a dummy body to the `all` rule, so that the `%` will not be considered by make.